### PR TITLE
Update Example_Interface_3.ts

### DIFF
--- a/Chapter05/Examples/Example_Interface_3.ts
+++ b/Chapter05/Examples/Example_Interface_3.ts
@@ -31,4 +31,4 @@ const product: ProductTemplate = {height:100, width:200, color: 'pink'}
 // instance product class with new product object 
 const newProduct = new ProductClass(product)
 // console our new product instance
-console.log(newProduct.product)
+console.log(newProduct.makeProduct())


### PR DESCRIPTION
The supporting text for this example reads as follows:
"In the preceding snippet, we build a product object and then pass it to our class's **makeProduct** function. We then console out the results, which is the same as before, except now our functional code is wrapped in a class."

So I'm assuming line 34 should be `newProduct.makeProduct()` instead of `newProduct.product`.

Note: I'm accessing the book online through O'Reilly. `newProduct.product` is present in the example code there as well.