### PR TITLE
Error during compilation

### DIFF
--- a/Chapter07/Examples/Example_PropertyInjection.ts
+++ b/Chapter07/Examples/Example_PropertyInjection.ts
@@ -1,5 +1,6 @@
 @Token
 class Teacher {
+    token: any;
     constructor (public id: number, public name: string) {}
 }
 function Token (constructor: Function) {


### PR DESCRIPTION
Having a class Teacher without an attribute "token" outlines an error in the IDE when consoling out a teacher["token"]. ![](https://i.imgur.com/Fw0mGjH.png)
The compilation is successful when the "token: any" attribute is added to the class.